### PR TITLE
Add cadence and watts to integral metrics (TCXFile)

### DIFF
--- a/sport_activities_features/tcx_manipulation.py
+++ b/sport_activities_features/tcx_manipulation.py
@@ -140,7 +140,11 @@ class TCXFile(FileManipulation):
                 'altitude_min': altitude_min,
                 'ascent': ascent,
                 'descent': descent,
-                'steps' : steps
+                'steps' : steps,
+                'cadence_avg': cadence_avg,
+                'cadence_max': cadence_max,
+                'watts_avg': watts_avg,
+                'watts_max': watts_max
             }.
         """
         tcx = TCXReader().read(filename)
@@ -210,6 +214,27 @@ class TCXFile(FileManipulation):
             steps = tcx.lx_ext['Steps']
         except BaseException:
             steps = None
+            
+        try:
+            cadence_avg = tcx.cadence_avg
+        except BaseException:
+            cadence_avg = None
+            
+        try:
+            cadence_max = tcx.cadence_max
+        except BaseException:
+            cadence_max = None  
+            
+        try:
+            watts_avg = tcx.tpx_ext_stats['Watts']['avg']
+        except BaseException:
+            watts_avg = None
+            
+        try:
+            watts_max = tcx.tpx_ext_stats['Watts']['max']
+        except BaseException:
+            watts_max = None     
+            
 
         int_metrics = {
             'activity_type': activity_type,
@@ -225,6 +250,10 @@ class TCXFile(FileManipulation):
             'ascent': ascent,
             'descent': descent,
             'steps': steps,
+            'cadence_avg': cadence_avg,
+            'cadence_max': cadence_max,
+            'watts_avg': watts_avg,
+            'watts_max': watts_max,
         }
         return int_metrics
 


### PR DESCRIPTION
Added missing code into extract_integral_metrics function to get the following data from TCX files: 
- cadence
- watts

The data is gathered from tcxreader library using TCXExercise's existing extension data statistics (tpx_ext_stats) and from TCXExercise's variables cadence_avg and cadence_max.
The function now returns a modified dictionary that contains all previously implemented data and additionally the following key-value pairs:
- _cadence_avg_ for average value of cadence,
- _cadence_max_ for maximum value of cadence, 
- _watts_avg_ for average value of power / watts
- _watts_max_ for maximum value of power / watts

Tested on the following files:
- 1/1.tcx (contains no data relevant to this implementation)
- 1/11.tcx (contains cadence and watts)

from the dataset ("[A collection of sport activity datasets with an emphasis on powermeter data](http://iztok-jr-fister.eu/static/publications/Sport5.zip)"), which was taken from [Sports Activity Dataset Collections](https://github.com/firefly-cpp/sports-activity-dataset-collections). The result CSV file is screenshotted and added to this PR.

[naloga2_sport5_test.csv](https://github.com/user-attachments/files/17908889/naloga2_sport5_test.csv)

![image](https://github.com/user-attachments/assets/e2bbf258-7000-4760-a4a0-94669056e587)
