### PR TITLE
Add speed average and speed max to TCXFile's extract_integral_metrics()

### DIFF
--- a/sport_activities_features/tcx_manipulation.py
+++ b/sport_activities_features/tcx_manipulation.py
@@ -144,7 +144,9 @@ class TCXFile(FileManipulation):
                 'cadence_avg': cadence_avg,
                 'cadence_max': cadence_max,
                 'watts_avg': watts_avg,
-                'watts_max': watts_max
+                'watts_max': watts_max,
+                'speed_avg': speed_avg,
+                'speed_max': speed_max
             }.
         """
         tcx = TCXReader().read(filename)
@@ -235,6 +237,17 @@ class TCXFile(FileManipulation):
         except BaseException:
             watts_max = None     
             
+        try:
+            speed_avg = tcx.avg_speed
+        except BaseException:
+            speed_avg = None     
+
+        try:
+            speed_max = tcx.max_speed
+        except BaseException:
+            speed_max = None     
+
+
 
         int_metrics = {
             'activity_type': activity_type,
@@ -254,6 +267,8 @@ class TCXFile(FileManipulation):
             'cadence_max': cadence_max,
             'watts_avg': watts_avg,
             'watts_max': watts_max,
+            'speed_avg': speed_avg,
+            'speed_max': speed_max
         }
         return int_metrics
 


### PR DESCRIPTION
Added missing code into extract_integral_metrics function to get the following data from TCX files:
- speed

The data is gathered from tcxreader library using TCXExercise's existing variables avg_speed and max_speed.
The function now returns a modified dictionary that contains all previously implemented data and additionally the following key-value pairs:
- speed_avg for average value of speed
- speed_max for maximum value of speed
