### PR TITLE
TCX/GPX Manipulation Refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,11 @@ from sport_activities_features.gpx_manipulation import GPXFile
 gpx_file=GPXFile()
 
 # Read the file and generate a dictionary with 
-data = gpx_file.read_one_file("path_to_the_file") # Represents data as dictionary of lists
+gpx_exercise = gpx_file.read_one_file("path_to_the_file")
+data = gpx_file.extract_activity_data(gpx_exercise) # Represents data as dictionary of lists
 
 # Alternative choice
-data = gpx_file.read_one_file("path_to_the_file", numpy_array= True) # Represents data as dictionary of numpy.arrays
+data = gpx_file.extract_activity_data(gpx_exercise, numpy_array= True) # Represents data as dictionary of numpy.arrays
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -154,10 +154,11 @@ from sport_activities_features.tcx_manipulation import TCXFile
 
 # Class for reading TCX files
 tcx_file=TCXFile()
-data = tcx_file.read_one_file("path_to_the_file") # Represents data as dictionary of lists
+tcx_exercise = tcx_file.read_one_file("path_to_the_file")
+data = tcx_file.extract_activity_data(tcx_exercise) # Represents data as dictionary of lists
 
 # Alternative choice
-data = tcx_file.read_one_file("path_to_the_file", numpy_array= True) # Represents data as dictionary of numpy.arrays
+data = tcx_file.extract_activity_data(tcx_exercise, numpy_array= True) # Represents data as dictionary of numpy.arrays
 
 ```
 
@@ -185,7 +186,8 @@ from sport_activities_features.plot_data import PlotData
 
 # Read TCX file
 tcx_file = TCXFile()
-activity = tcx_file.read_one_file("path_to_the_file")
+tcx_exercise = tcx_file.read_one_file("path_to_the_file")
+activity = tcx_file.extract_activity_data(tcx_exercise)
 
 # Detect hills in data
 Hill = HillIdentification(activity['altitudes'], 30)
@@ -211,7 +213,8 @@ from sport_activities_features.tcx_manipulation import TCXFile
 
 # Reading the TCX file
 tcx_file = TCXFile()
-activity = tcx_file.read_one_file("path_to_the_data")
+tcx_exercise = tcx_file.read_one_file("path_to_the_file")
+activity = tcx_file.extract_activity_data(tcx_exercise)
 
 # Identifying the intervals in the activity by power
 Intervals = IntervalIdentificationByPower(activity["distances"], activity["timestamps"], activity["altitudes"], 70)
@@ -231,7 +234,8 @@ from sport_activities_features import TCXFile
 
 # Read TCX file
 tcx_file = TCXFile()
-tcx_data = tcx_file.read_one_file("path_to_file")
+tcx_exercise = tcx_file.read_one_file("path_to_the_file")
+tcx_data = tcx_file.extract_activity_data(tcx_exercise)
 
 # Configure visual crossing api key
 visual_crossing_api_key = "weather_api_key" # https://www.visualcrossing.com/weather-api
@@ -285,8 +289,8 @@ from sport_activities_features.tcx_manipulation import TCXFile
 
 # Read TCX file
 tcx_file = TCXFile()
-
-integral_metrics = tcx_file.extract_integral_metrics("path_to_the_file")
+tcx_exercise = tcx_file.read_one_file("path_to_the_file")
+integral_metrics = tcx_file.extract_integral_metrics(tcx_exercise)
 
 print(integral_metrics)
 
@@ -299,7 +303,9 @@ from sport_activities_features.tcx_manipulation import TCXFile
 
 #read TCX file
 tcx_file = TCXFile()
-tcx_data = tcx_file.read_one_file("path_to_the_file")
+tcx_exercise = tcx_file.read_one_file("path_to_the_file")
+tcx_data = tcx_file.extract_activity_data(tcx_exercise)
+
 
 #configure visual crossing api key
 visual_crossing_api_key = "API_KEY" # https://www.visualcrossing.com/weather-api
@@ -351,7 +357,8 @@ from sport_activities_features.tcx_manipulation import TCXFile
 
 # Reading the TCX file.
 tcx_file = TCXFile()
-activity = tcx_file.read_one_file('path_to_the_data')
+tcx_exercise = tcx_file.read_one_file("path_to_the_file")
+activity = tcx_file.extract_activity_data(tcx_exercise)
 
 # Converting the read data to arrays.
 positions = np.array([*activity['positions']])
@@ -381,7 +388,8 @@ Identify interruption events from a TCX or GPX file.
 
 # read TCX file (also works with GPX files)
 tcx_file = TCXFile()
-tcx_data = tcx_file.read_one_file("path_to_the_data")
+tcx_exercise = tcx_file.read_one_file("path_to_the_file")
+tcx_data = tcx_file.extract_activity_data(tcx_exercise)
 
 """
 Time interval = time before and after the start of an event
@@ -434,7 +442,8 @@ from sport_activities_features import ElevationIdentification
 from sport_activities_features import TCXFile
 
 tcx_file = TCXFile()
-tcx_data = tcx_file.read_one_file('path_to_file')
+tcx_exercise = tcx_file.read_one_file("path_to_the_file")
+tcx_data = tcx_file.extract_activity_data(tcx_exercise)
 
 elevations = ElevationIdentification(tcx_data['positions'])
 """Adds tcx_data['elevation'] = eg. [124, 21, 412] for each position"""

--- a/examples/calculate_training_load.py
+++ b/examples/calculate_training_load.py
@@ -11,7 +11,8 @@ from sport_activities_features import (
 
 # Reading a TCX file.
 tcx_file = TCXFile()
-activity = tcx_file.read_one_file('../datasets/15.tcx')
+tcx_exercise = tcx_file.read_one_file('../datasets/15.tcx')
+activity = tcx_file.extract_activity_data(tcx_exercise)
 
 timestamps = activity['timestamps']
 heart_rates = activity['heartrates']

--- a/examples/convert_gpx_to_csv.py
+++ b/examples/convert_gpx_to_csv.py
@@ -12,8 +12,9 @@ input_file = 'path_to_original_file'
 output_file = 'path_to_output_file'
 
 # Read GPX file
-data = gpx_file.read_one_file(
-    input_file,
+gpx_exercise = gpx_file.read_one_file(input_file)
+data = gpx_file.extract_activity_data(
+    gpx_exercise,
 )  # Represents data as dictionary of lists
 
 # Convert dictionary of lists to pandas DataFrame

--- a/examples/convert_tcx_to_csv.py
+++ b/examples/convert_tcx_to_csv.py
@@ -12,8 +12,9 @@ input_file = 'path_to_original_file'
 output_file = 'path_to_output_file'
 
 # Read TCX file
-data = tcx_file.read_one_file(
-    input_file,
+tcx_exercise = tcx_file.read_one_file(input_file)
+data = tcx_file.extract_activity_data(
+    tcx_exercise,
 )  # Represents data as dictionary of lists
 
 # Convert dictionary of lists to pandas DataFrame

--- a/examples/dead_end_extraction.py
+++ b/examples/dead_end_extraction.py
@@ -8,7 +8,8 @@ from sport_activities_features.tcx_manipulation import TCXFile
 
 # Reading the TCX file.
 tcx_file = TCXFile()
-activity = tcx_file.read_one_file('path_to_the_file')
+tcx_exercise = tcx_file.read_one_file('path_to_the_file')
+activity = tcx_file.extract_activity_data(tcx_exercise)
 
 # Converting the read data to the array.
 positions = np.array([*activity['positions']])

--- a/examples/draw_map_with_identified_hills.py
+++ b/examples/draw_map_with_identified_hills.py
@@ -6,7 +6,8 @@ from sport_activities_features.tcx_manipulation import TCXFile
 # read TCX file
 tcx_file = TCXFile()
 
-data = tcx_file.read_one_file('path_to_the_data')
+tcx_exercise = tcx_file.read_one_file('path_to_the_data')
+data = tcx_file.extract_activity_data(tcx_exercise)
 
 # detect hills in data
 Hill = HillIdentification(data['altitudes'], 30)

--- a/examples/draw_map_with_identified_intervals.py
+++ b/examples/draw_map_with_identified_intervals.py
@@ -8,6 +8,7 @@ from sport_activities_features.tcx_manipulation import TCXFile
 
 # Reading the TCX file
 tcx_file = TCXFile()
+tcx_exercise = tcx_file.read_one_file('path_to_the_data')
 (
     activity_type,
     positions,
@@ -17,7 +18,7 @@ tcx_file = TCXFile()
     timestamps,
     heartrates,
     speeds,
-) = tcx_file.read_one_file('path_to_the_data').values()
+) = tcx_file.extract_activity_data(tcx_exercise).values()
 
 # Identifying the intervals in the activity by power and drawing the map
 Intervals = IntervalIdentificationByPower(distances, timestamps, altitudes, 70)

--- a/examples/extract_data_inside_area.py
+++ b/examples/extract_data_inside_area.py
@@ -16,7 +16,8 @@ progress = 0.0
 # Reading all files in filder.
 for file in all_files:
     print('\rProgress: ', int(progress), '%', end='')
-    activity = tcx_file.read_one_file(file)
+    tcx_exercise = tcx_file.read_one_file(file)
+    activity = tcx_file.extract_activity_data(tcx_exercise)
 
     # Converting the read data to arrays.
     positions = np.array([*activity['positions']])

--- a/examples/hill_data_extraction.py
+++ b/examples/hill_data_extraction.py
@@ -4,7 +4,8 @@ from sport_activities_features.topographic_features import TopographicFeatures
 
 # read TCX file
 tcx_file = TCXFile()
-activity = tcx_file.read_one_file('path_to_the_data')
+tcx_exercise = tcx_file.read_one_file('path_to_the_data')
+activity = tcx_file.extract_activity_data(tcx_exercise)
 
 # detect hills in data
 Hill = HillIdentification(activity['altitudes'], 30)

--- a/examples/identify_interruptions.py
+++ b/examples/identify_interruptions.py
@@ -9,7 +9,8 @@ Identify interruption events from a TCX or GPX file.
 
 # read TCX file (also works with GPX files)
 tcx_file = TCXFile()
-tcx_data = tcx_file.read_one_file('path_to_the_data')
+tcx_exercise = tcx_file.read_one_file('path_to_the_data')
+tcx_data = tcx_file.extract_activity_data(tcx_exercise)
 
 """
 Time interval = time before and after the start of an event

--- a/examples/integral_metrics_extraction.py
+++ b/examples/integral_metrics_extraction.py
@@ -3,6 +3,7 @@ from sport_activities_features.tcx_manipulation import TCXFile
 # read TCX file
 tcx_file = TCXFile()
 # extract integral metrics ans store it in dictionary
-integral_metrics = tcx_file.extract_integral_metrics('path_to_the_file')
+tcx_exercise = tcx_file.read_one_file('path_to_the_file')
+integral_metrics = tcx_file.extract_integral_metrics(tcx_exercise)
 
 print(integral_metrics)

--- a/examples/interval_data_extraction.py
+++ b/examples/interval_data_extraction.py
@@ -9,7 +9,8 @@ from sport_activities_features.tcx_manipulation import TCXFile
 
 # Reading the TCX file
 tcx_file = TCXFile()
-activity = tcx_file.read_one_file('path_to_the_data')
+tcx_exercise = tcx_file.read_one_file('path_to_the_data')
+activity = tcx_file.extract_activity_data(tcx_exercise)
 
 # Identifying the intervals in the activity by power
 Intervals = IntervalIdentificationByPower(

--- a/examples/missing_elevation_data_extraction.py
+++ b/examples/missing_elevation_data_extraction.py
@@ -1,7 +1,8 @@
 from sport_activities_features import ElevationIdentification, TCXFile
 
 tcx_file = TCXFile()
-tcx_data = tcx_file.read_one_file('path_to_the_data')
+tcx_exercise = tcx_file.read_one_file('path_to_the_data')
+tcx_data = tcx_file.extract_activity_data(tcx_exercise)
 
 elevations = ElevationIdentification(tcx_data['positions'])
 """Adds tcx_data['elevation'] = eg. [124, 21, 412] for each position"""

--- a/examples/read_all_files.py
+++ b/examples/read_all_files.py
@@ -15,9 +15,10 @@ all_files = tcx_file.read_directory('path_to_the_folder')
 # Extracting the data of all files
 activities = []
 for file in all_files:
+    tcx_exercise = tcx_file.read_one_file(file)
     activity = {'ID': os.path.splitext(os.path.split(file)[-1])[0]}
-    activity.update(tcx_file.read_one_file(file))
-    activity.update(tcx_file.extract_integral_metrics(file))
+    activity.update(tcx_file.extract_activity_data(tcx_exercise))
+    activity.update(tcx_file.extract_integral_metrics(tcx_exercise))
 
     # Hills
     Hill = HillIdentification(activity['altitudes'], 30)

--- a/examples/read_folder.py
+++ b/examples/read_folder.py
@@ -6,5 +6,6 @@ all_files = tcx_file.read_directory('path_to_the_folder')
 
 # iterate through files and print total distance of activities
 for i in range(len(all_files)):
-    activity = tcx_file.read_one_file(all_files[i])
+    tcx_exercise = tcx_file.read_one_file(all_files[i])
+    activity = tcx_file.extract_activity_data(tcx_exercise)
     print('total distance: ', activity['total_distance'] / 1000)

--- a/examples/read_gpx_file.py
+++ b/examples/read_gpx_file.py
@@ -2,4 +2,5 @@ from sport_activities_features import GPXFile
 
 # read GPX file
 gpx_file = GPXFile()
-data = gpx_file.read_one_file('path_to_the_file')
+gpx_exercise = gpx_file.read_one_file('path_to_the_file')
+data = gpx_file.extract_activity_data(gpx_exercise)

--- a/examples/read_tcx_file.py
+++ b/examples/read_tcx_file.py
@@ -2,4 +2,5 @@ from sport_activities_features import TCXFile
 
 # read TCX file
 tcx_file = TCXFile()
-data = tcx_file.read_one_file('path_to_the_file')
+tcx_exercise = tcx_file.read_one_file('path_to_the_file')
+data = tcx_file.extract_activity_data(tcx_exercise)

--- a/examples/weather_data_extraction.py
+++ b/examples/weather_data_extraction.py
@@ -2,7 +2,8 @@ from sport_activities_features import TCXFile, WeatherIdentification
 
 # Read TCX file
 tcx_file = TCXFile()
-tcx_data = tcx_file.read_one_file('path_to_the_file')
+tcx_exercise = tcx_file.read_one_file('path_to_the_file')
+tcx_data = tcx_file.extract_activity_data(tcx_exercise)
 
 # Configure visual crossing api key
 # https://www.visualcrossing.com/weather-api

--- a/sport_activities_features/tcx_manipulation.py
+++ b/sport_activities_features/tcx_manipulation.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 from tcx2gpx import tcx2gpx
-from tcxreader.tcxreader import TCXReader, TCXTrackPoint
+from tcxreader.tcxreader import TCXReader, TCXTrackPoint, TCXExercise
 
 from sport_activities_features.file_manipulation import FileManipulation
 
@@ -31,13 +31,29 @@ class TCXFile(FileManipulation):
             self.all_files.append(file)
         return self.all_files
 
-    def read_one_file(self, filename: str, numpy_array=False) -> dict:
-        """Method for parsing one TCX file using the TCXReader.\n
+    def read_one_file(self, filename: str) -> dict:
+        """Method for reading a TCXExercise object using the TCXReader.\n
         Args:
             filename (str):
                 name of the TCX file to be read
+        Returns:
+            tcx (TCXExercise):
+                TCXExercise object with all the data from the file.
+
+        Note:
+            In the case of missing value in raw data, we assign None.
+        """
+        tcx = TCXReader().read(filename)
+        return tcx
+        
+
+    def extract_activity_data(self, tcx: TCXExercise, numpy_array = False) -> dict:
+        """Method for parsing one TCX file using the TCXReader.\n
+        Args:
+            tcx (TCXExercise):
+                TCXExercise object to be read
             numpy_array (bool):
-                if set to True dictionary lists are transformed into numpy arrays
+                if True, dictionary lists are transformed into numpy arrays
         Returns:
             dict:
             {
@@ -54,8 +70,6 @@ class TCXFile(FileManipulation):
         Note:
             In the case of missing value in raw data, we assign None.
         """
-        tcx = TCXReader().read(filename)
-
         # handling missing data - should be improved in original tcxparser
         try:
             activity_type = tcx.activity_type
@@ -119,12 +133,12 @@ class TCXFile(FileManipulation):
             'start_time': tcx.start_time,
         }
         return activity
-
-    def extract_integral_metrics(self, filename: str) -> dict:
-        """Method for parsing one TCX file and extracting integral metrics.\n
+    
+    def extract_integral_metrics(self, tcx_exercise: TCXExercise) -> dict:
+        """Method for extracting integral metrics from a TCXExercise.\n
         Args:
-            filename (str):
-                name of the TCX file to be read
+            tcx_exercise (TCXExercise):
+                TCXExercise object to be read
         Returns:
             dict:
             {
@@ -149,101 +163,100 @@ class TCXFile(FileManipulation):
                 'speed_max': speed_max
             }.
         """
-        tcx = TCXReader().read(filename)
 
         # handling missing data in raw files
         try:
-            activity_type = tcx.activity_type
+            activity_type = tcx_exercise.activity_type
         except BaseException:
             activity_type = None
 
         try:
-            distance = tcx.distance
+            distance = tcx_exercise.distance
         except BaseException:
             distance = None
 
         try:
-            duration = tcx.duration
+            duration = tcx_exercise.duration
         except BaseException:
             duration = None
 
         try:
-            calories = tcx.calories
+            calories = tcx_exercise.calories
         except BaseException:
             calories = None
 
         try:
-            hr_avg = tcx.hr_avg
+            hr_avg = tcx_exercise.hr_avg
         except BaseException:
             hr_avg = None
 
         try:
-            hr_max = tcx.hr_max
+            hr_max = tcx_exercise.hr_max
         except BaseException:
             hr_max = None
 
         try:
-            hr_min = tcx.hr_min
+            hr_min = tcx_exercise.hr_min
         except BaseException:
             hr_min = None
 
         try:
-            altitude_avg = tcx.altitude_avg
+            altitude_avg = tcx_exercise.altitude_avg
         except BaseException:
             altitude_avg = None
 
         try:
-            altitude_max = tcx.altitude_max
+            altitude_max = tcx_exercise.altitude_max
         except BaseException:
             altitude_max = None
 
         try:
-            altitude_min = tcx.altitude_min
+            altitude_min = tcx_exercise.altitude_min
         except BaseException:
             altitude_min = None
 
         try:
-            ascent = tcx.ascent
+            ascent = tcx_exercise.ascent
         except BaseException:
             ascent = None
 
         try:
-            descent = tcx.descent
+            descent = tcx_exercise.descent
         except BaseException:
             descent = None
 
         try:
-            steps = tcx.lx_ext['Steps']
+            steps = tcx_exercise.lx_ext['Steps']
         except BaseException:
             steps = None
             
         try:
-            cadence_avg = tcx.cadence_avg
+            cadence_avg = tcx_exercise.cadence_avg
         except BaseException:
             cadence_avg = None
             
         try:
-            cadence_max = tcx.cadence_max
+            cadence_max = tcx_exercise.cadence_max
         except BaseException:
             cadence_max = None  
             
         try:
-            watts_avg = tcx.tpx_ext_stats['Watts']['avg']
+            watts_avg = tcx_exercise.tpx_ext_stats['Watts']['avg']
         except BaseException:
             watts_avg = None
             
         try:
-            watts_max = tcx.tpx_ext_stats['Watts']['max']
+            watts_max = tcx_exercise.tpx_ext_stats['Watts']['max']
         except BaseException:
             watts_max = None     
             
         try:
-            speed_avg = tcx.avg_speed
+            speed_avg = tcx_exercise.avg_speed
         except BaseException:
             speed_avg = None     
 
         try:
-            speed_max = tcx.max_speed
+            speed_max = tcx_exercise.max_speed
         except BaseException:
             speed_max = None     
 

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -10,7 +10,7 @@ UTF8 formatted Gpx files testing (Thanks Luka Koprivc for donating these test fi
 - cross-country-skiing_activity_1.tcx: an activity that represents cross-country skiing activity
 written in the tcx file
 
-- nodes-test.temp: pickled array of position nodes retrieved from dictionary TcxFile.read_one_file(filename)['positions'] 
+- nodes-test.temp: pickled array of position nodes retrieved from dictionary TCXFile.extract_activity_data(tcx_exercise)['positions'] 
 
 - pool_swim-activity_1.tcx: an activity that represents pool swim activity
 written in the tcx file

--- a/tests/test_area_identification.py
+++ b/tests/test_area_identification.py
@@ -11,7 +11,8 @@ class TestAreaIdentification(TestCase):
     def setUp(self):
         filename = os.path.join(os.path.dirname(__file__), 'data', '15.tcx')
         tcx_file = TCXFile()
-        self.activity = tcx_file.read_one_file(filename)
+        tcx_exercise = tcx_file.read_one_file(filename)
+        self.activity = tcx_file.extract_activity_data(tcx_exercise)
 
         # Converting the read data to arrays.
         positions = np.array([*self.activity['positions']])

--- a/tests/test_dead_end_identification.py
+++ b/tests/test_dead_end_identification.py
@@ -14,7 +14,8 @@ class TestDeadEndIdentification(TestCase):
         # Reading the TCX file.
         filename = os.path.join(os.path.dirname(__file__), 'data', '15.tcx')
         tcx_file = TCXFile()
-        self.activity = tcx_file.read_one_file(filename)
+        tcx_exercise = tcx_file.read_one_file(filename)
+        self.activity = tcx_file.extract_activity_data(tcx_exercise)
 
         self.positions = np.array([*self.activity['positions']])
         self.distances = np.array([*self.activity['distances']])

--- a/tests/test_different_activities.py
+++ b/tests/test_different_activities.py
@@ -8,7 +8,9 @@ class TestTCXFile(TestCase):
     def setUp(self):
         filename = os.path.join(os.path.dirname(__file__), 'data', '15.tcx')
         self.tcx_file = TCXFile()
-        self.data = self.tcx_file.read_one_file(filename)
+        tcx_exercise = self.tcx_file.read_one_file(filename)
+        self.data = self.tcx_file.extract_activity_data(tcx_exercise)
+        
 
     def test_total_distance(self):
         self.assertAlmostEqual(self.data['total_distance'], 116366.98, 2)
@@ -29,7 +31,8 @@ class TestSupTCXFile(TestCase):
             os.path.dirname(__file__), 'data', 'sup_activity_1.tcx',
         )
         self.tcx_file = TCXFile()
-        self.data = self.tcx_file.extract_integral_metrics(filename)
+        tcx_exercise = self.tcx_file.read_one_file(filename)
+        self.data = self.tcx_file.extract_integral_metrics(tcx_exercise)
 
     def test_total_steps(self):
         assert self.data['steps'] == 491
@@ -43,7 +46,8 @@ class TestSwimmingTCXFile(TestCase):
             os.path.dirname(__file__), 'data', 'swimming_activity_1.tcx',
         )
         self.tcx_file = TCXFile()
-        self.data = self.tcx_file.extract_integral_metrics(filename)
+        tcx_exercise = self.tcx_file.read_one_file(filename)
+        self.data = self.tcx_file.extract_integral_metrics(tcx_exercise)
 
     def test_total_calories(self):
         assert self.data['calories'] == 284
@@ -62,7 +66,8 @@ class TestCrossCountryTCXFile(TestCase):
             'cross-country-skiing_activity_1.tcx',
         )
         self.tcx_file = TCXFile()
-        self.data = self.tcx_file.extract_integral_metrics(filename)
+        tcx_exercise = self.tcx_file.read_one_file(filename)
+        self.data = self.tcx_file.extract_integral_metrics(tcx_exercise)
 
     def test_total_calories(self):
         assert self.data['calories'] == 532
@@ -79,7 +84,8 @@ class TestWalkingTCXFile(TestCase):
             os.path.dirname(__file__), 'data', 'walking_activity_1.tcx',
         )
         self.tcx_file = TCXFile()
-        self.data = self.tcx_file.extract_integral_metrics(filename)
+        tcx_exercise = self.tcx_file.read_one_file(filename)
+        self.data = self.tcx_file.extract_integral_metrics(tcx_exercise)
 
     def test_total_calories(self):
         assert self.data['calories'] == 329
@@ -96,7 +102,8 @@ class TestPoolSwimmingTCXFile(TestCase):
             os.path.dirname(__file__), 'data', 'pool_swim-activity_1.tcx',
         )
         self.tcx_file = TCXFile()
-        self.data = self.tcx_file.extract_integral_metrics(filename)
+        tcx_exercise = self.tcx_file.read_one_file(filename)
+        self.data = self.tcx_file.extract_integral_metrics(tcx_exercise)
 
     def test_total_calories(self):
         assert self.data['calories'] == 329

--- a/tests/test_file_manipulation.py
+++ b/tests/test_file_manipulation.py
@@ -8,8 +8,9 @@ class TestTCXFile(TestCase):
     def setUp(self):
         filename = os.path.join(os.path.dirname(__file__), 'data', '15.tcx')
         self.tcx_file: TCXFile = TCXFile()
-        self.data_with_missing = self.tcx_file.read_one_file(filename)
-        self.data_without_missing = self.tcx_file.read_one_file(filename)
+        tcx_exercise = self.tcx_file.read_one_file(filename)
+        self.data_with_missing = self.tcx_file.extract_activity_data(tcx_exercise)
+        self.data_without_missing = self.tcx_file.extract_activity_data(tcx_exercise)
         self.tcx_file.linear_fill_missing_values(
             self.data_without_missing, 'heartrates', 15,
         )

--- a/tests/test_gpx_file.py
+++ b/tests/test_gpx_file.py
@@ -10,7 +10,8 @@ class TestGPXFile(TestCase):
             os.path.dirname(__file__), 'data', 'riderx3.gpx',
         )
         self.gpx_file = GPXFile()
-        self.data = self.gpx_file.read_one_file(filename)
+        gpx_exercise = self.gpx_file.read_one_file(filename)
+        self.data = self.gpx_file.extract_activity_data(gpx_exercise)
 
     def test_total_distance(self):
         self.assertAlmostEqual(self.data['total_distance'], 5774.703, 2)
@@ -39,7 +40,8 @@ class TestGPXFile(TestCase):
         ]
         for index, f in enumerate(utf8_filenames):
             filename = os.path.join(os.path.dirname(__file__), 'data', f)
-            data = self.gpx_file.read_one_file(filename)
+            gpx_exercise = self.gpx_file.read_one_file(filename)
+            data = self.gpx_file.extract_activity_data(gpx_exercise)
             self.assertAlmostEqual(
                 data['total_distance'], utf8_distances[index], places=5,
             )

--- a/tests/test_hill_identification.py
+++ b/tests/test_hill_identification.py
@@ -13,7 +13,8 @@ class TestHillIdentification(TestCase):
     def setUp(self):
         filename = os.path.join(os.path.dirname(__file__), "data", "15.tcx")
         tcx_file = TCXFile()
-        self.activity = tcx_file.read_one_file(filename)
+        tcx_exercise = tcx_file.read_one_file(filename)
+        self.activity = tcx_file.extract_activity_data(tcx_exercise)
         self.hill = HillIdentification(
             self.activity["altitudes"], self.activity["distances"], 30
         )

--- a/tests/test_interruptions.py
+++ b/tests/test_interruptions.py
@@ -9,7 +9,8 @@ class TestInterruptionProcessor(TestCase):
     def setUp(self):
         filename = os.path.join(os.path.dirname(__file__), 'data', '15.tcx')
         tcx_file = TCXFile()
-        tcx = tcx_file.read_one_file(filename)
+        tcx_exercise = tcx_file.read_one_file(filename)
+        tcx = tcx_file.extract_activity_data(tcx_exercise)
 
         interruptionProcessor = InterruptionProcessor(
             time_interval=60,

--- a/tests/test_interval_identification.py
+++ b/tests/test_interval_identification.py
@@ -12,7 +12,8 @@ class TestHillIdentification(TestCase):
     def setUp(self):
         filename = os.path.join(os.path.dirname(__file__), 'data', '2.tcx')
         tcx_file = TCXFile()
-        self.activity = tcx_file.read_one_file(filename)
+        tcx_exercise = tcx_file.read_one_file(filename)
+        self.activity = tcx_file.extract_activity_data(tcx_exercise)
 
         # Identifying the intervals in the activity by power
         IntervalsPower = IntervalIdentificationByPower(

--- a/tests/test_tcx_file.py
+++ b/tests/test_tcx_file.py
@@ -8,7 +8,8 @@ class TestTCXFile(TestCase):
     def setUp(self):
         filename = os.path.join(os.path.dirname(__file__), 'data', '15.tcx')
         self.tcx_file = TCXFile()
-        self.data = self.tcx_file.read_one_file(filename)
+        tcx_exercise = self.tcx_file.read_one_file(filename)
+        self.data = self.tcx_file.extract_activity_data(tcx_exercise)
 
     def test_total_distance(self):
         self.assertAlmostEqual(self.data['total_distance'], 116366.98, 2)

--- a/tests/test_training_loads.py
+++ b/tests/test_training_loads.py
@@ -61,7 +61,8 @@ class EdwardsTRIMPTestCase(TestCase):
         """Setting up the test."""
         filename = os.path.join(os.path.dirname(__file__), 'data', '15.tcx')
         tcx_file = TCXFile()
-        activity = tcx_file.read_one_file(filename)
+        tcx_exercise = tcx_file.read_one_file(filename)
+        activity = tcx_file.extract_activity_data(tcx_exercise)
         timestamps = activity['timestamps']
         heart_rates = activity['heartrates']
         self.__edwards = EdwardsTRIMP(heart_rates, timestamps, 200)
@@ -86,7 +87,8 @@ class LuciaTRIMPTestCase(TestCase):
         """Setting up the test."""
         filename = os.path.join(os.path.dirname(__file__), 'data', '15.tcx')
         tcx_file = TCXFile()
-        activity = tcx_file.read_one_file(filename)
+        tcx_exercise = tcx_file.read_one_file(filename)
+        activity = tcx_file.extract_activity_data(tcx_exercise)
         timestamps = activity['timestamps']
         heart_rates = activity['heartrates']
         self.__lucia = LuciaTRIMP(heart_rates, timestamps, VT1=160, VT2=180)

--- a/tests/test_training_metrics.py
+++ b/tests/test_training_metrics.py
@@ -10,8 +10,9 @@ class TestTrainingMetrics(TestCase):
     def setUp(self):
         filename = os.path.join(os.path.dirname(__file__), 'data', '11.tcx')
         self.tcx_file = TCXFile()
-        self.data = self.tcx_file.extract_integral_metrics(filename)
-        self.raw_data = TCXReader().read(filename)
+        tcx_exercise = self.tcx_file.read_one_file(filename)        
+        self.data = self.tcx_file.extract_integral_metrics(tcx_exercise)
+        self.raw_data = tcx_exercise
         
     def test_functional_threshold_power(self):
         tm_instance = TrainingMetrics()

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -14,7 +14,8 @@ class TestWeather(TestCase):
             'weather_test.temp',
         )
         tcx_file = TCXFile()
-        self.data = tcx_file.read_one_file(filename)
+        tcx_exercise = tcx_file.read_one_file(filename)
+        self.data = tcx_file.extract_activity_data(tcx_exercise)
         self.weather = None
         with open(weather_external_data, 'rb') as input:
             self.weather = pickle.load(input)


### PR DESCRIPTION
# General
Implemented changes per suggestion in the issue #199. These are **BREAKING** changes and the projects that use this library should also rewrite their code to reflect these changes. The reading of files and further manipulation of data is now optimized so the file is only read once, parsed and then stored in-memory. 

## Before changes
If you needed both activity data and integral metrics, the file would be read twice. With a big collection of files, this would slow down the processing time.
## After changes
If you need both activity data and integral metrics, the file is read once. You can then pass the exercise object into methods for activity data and integral metrics and get the results. This results in processing time to be at least halved.
However, as the file is stored in-memory as long as it is needed, the memory consumption gets increased. This is not a problem when reading the files one by one, but when multiprocessing, the user should be wary of their memory consumption.


# Changes
## TCX
- split read_one_file() into two methods:
  - one returns an instance of TCXExercise (read_one_file),
  - one extracts and returns a dictionary of activity data (extract_activity_data),
- extract_integral_metrics() now takes a TCXExercise object instead of filename,
- refactored the relevant tests to reflect these changes,
- rewritten the relevant examples to reflect these changes (both the code and README),
- rewritten the documentation to reflect these changes,

## GPX
- created a new class called GPXExercise with raw data, list of trackpoints and calculated values (ensuring consistency between TCX and GPX)
- split read_one_file() into two methods:
  - one returns an instance of GPXExercise (read_one_file),
  - one extracts and returns a dictionary of activity data (extract_activity_data),
- extract_integral_metrics() now takes a GPXExercise object instead of filename
- refactored the relevant tests to reflect these changes,
- rewritten the relevant examples to reflect these changes (both the code and README),
- rewritten the documentation to reflect these changes.